### PR TITLE
Feat: Add client support for Kurios bandwidth control

### DIFF
--- a/plico_motor/__version__.py
+++ b/plico_motor/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 0, 5)
+VERSION = (0, 0, 6)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/plico_motor/client/abstract_motor_client.py
+++ b/plico_motor/client/abstract_motor_client.py
@@ -46,6 +46,32 @@ class AbstractMotorClient(with_metaclass(abc.ABCMeta, object)):
     def status(self):
         assert False
 
+    @abc.abstractmethod
+    @returns(int)
+    def get_bandwidth_mode(self):
+        """
+        Get the current bandwidth mode of the filter.
+
+        Returns
+        -------
+        int
+            Current bandwidth mode (e.g., 1=BLACK, 2=WIDE, 4=MEDIUM, 8=NARROW).
+        """
+        assert False
+
+    @abc.abstractmethod
+    @returnsNone
+    def set_bandwidth_mode(self, mode: int):
+        """
+        Set the bandwidth mode of the filter.
+
+        Parameters
+        ----------
+        mode : int
+            Desired bandwidth mode.
+        """
+        assert False
+
 # def _proposed_interface():
 #     x = plico_motor.client('ip', axis=0, port=port)
 #     x.home()

--- a/plico_motor/client/motor_client.py
+++ b/plico_motor/client/motor_client.py
@@ -3,7 +3,7 @@ from plico_motor.client.abstract_motor_client import AbstractMotorClient
 from plico.rpc.abstract_remote_procedure_call import \
     AbstractRemoteProcedureCall
 from plico.utils.logger import Logger
-from plico.utils.decorator import override, returns
+from plico.utils.decorator import override, returns, returnsNone
 from plico.utils.snapshotable import Snapshotable
 from plico.client.serverinfo_client import ServerInfoClient
 from plico.client.hackerable_client import HackerableClient
@@ -96,3 +96,23 @@ class MotorClient(AbstractMotorClient,
     @override
     def velocity(self):
         return int(self.status().velocity)
+    
+    @override
+    @returns(int)
+    def get_bandwidth_mode(self,
+                       timeout_in_sec=Timeout.GETTER):
+        self._logger.debug("Getting bandwidth mode")
+        return self._rpcHandler.sendRequest(
+            self._requestSocket, 'get_bandwidth_mode',
+            [self._axis],
+            timeout=timeout_in_sec)
+
+    @override
+    @returnsNone
+    def set_bandwidth_mode(self, mode: int,
+                       timeout_in_sec=Timeout.SETTER):
+        self._logger.notice(f"Setting bandwidth mode to {mode}")
+        return self._rpcHandler.sendRequest(
+            self._requestSocket, 'set_bandwidth_mode',
+            [self._axis, mode],
+            timeout=timeout_in_sec)

--- a/plico_motor/gui/motor_control_gui.py
+++ b/plico_motor/gui/motor_control_gui.py
@@ -11,21 +11,21 @@ class Runner(object):
 
     def _setUp(self, host='localhost', port=7200, axis=1):
 
-        def moveby(gui):
+        def moveby(gui, *args, **kwargs):
             nsteps = int(gui.nstepsby)
             if self.motor:
                 self.motor.move_by(nsteps)
 
-        def moveto(gui):
+        def moveto(gui, *args, **kwargs):
             nsteps = int(gui.nstepsto)
             if self.motor:
                 self.motor.move_to(nsteps)
 
-        def home(gui):
+        def home(gui, *args, **kwargs):
             if self.motor:
                 self.motor.home()
 
-        def getstatus(gui):
+        def getstatus(gui, *args, **kwargs):
             try:
                 if self.motor:
                     gui.pos = self.motor.position()
@@ -37,7 +37,7 @@ class Runner(object):
                 gui.pos = str(e)
                 gui.status = 'Not connected'
 
-        def connect(gui):
+        def connect(gui, *args, **kwargs):
             host = gui.host
             port = gui.port
             axis = gui.axis


### PR DESCRIPTION
Added get_bandwidth_mode and set_bandwidth_mode to client interface: Defined abstract methods in plico_motor/client/abstract_motor_client.py. Implemented corresponding methods in plico_motor/client/motor_client.py. These methods send the appropriate RPC requests (get_bandwidth_mode, set_bandwidth_mode) along with the axis identifier and any necessary arguments (like mode) to the server. Included relevant @returns and @returnsNone decorators.